### PR TITLE
Small cleanup and fixes

### DIFF
--- a/AutoIngest/Source/DTITCReportManager.m
+++ b/AutoIngest/Source/DTITCReportManager.m
@@ -7,9 +7,7 @@
 //
 
 #import "DTITCReportManager.h"
-#import "DTITCConstants.h"
 #import "AccountManager.h"
-#import "GenericAccount.h"
 
 static DTITCReportManager *_sharedInstance = nil;
 
@@ -20,8 +18,6 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 @implementation DTITCReportManager
 {
     BOOL _synching;
-    
-    id defaultsObserver;
     
     NSString *_reportFolder;
     NSString *_vendorID;
@@ -60,7 +56,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:defaultsObserver];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 

--- a/AutoIngest/Source/DTITCReportManager.m
+++ b/AutoIngest/Source/DTITCReportManager.m
@@ -305,7 +305,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
     if ([defaults boolForKey:@"DownloadWeekly"])
     {
         [_queue addOperationWithBlock:^{
-            [self _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeWeekly fromAccount:account];
+            [weakself _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeWeekly fromAccount:account];
         }];
         
         hasWorkToDo = YES;
@@ -314,7 +314,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
     if ([defaults boolForKey:@"DownloadMonthly"])
     {
         [_queue addOperationWithBlock:^{
-            [self _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeMonthly fromAccount:account];
+            [weakself _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeMonthly fromAccount:account];
         }];
         
         hasWorkToDo = YES;
@@ -323,7 +323,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
     if ([defaults boolForKey:@"DownloadYearly"])
     {
         [_queue addOperationWithBlock:^{
-            [self _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeYearly fromAccount:account];
+            [weakself _downloadAllReportsOfType:ITCReportTypeSales subType:ITCReportSubTypeSummary dateType:ITCReportDateTypeYearly fromAccount:account];
         }];
         
         hasWorkToDo = YES;

--- a/AutoIngest/Source/PreferencesWindowController.m
+++ b/AutoIngest/Source/PreferencesWindowController.m
@@ -11,9 +11,6 @@
 #import "AccountManager.h"
 #import "GenericAccount.h"
 
-#import "SSKeychain.h"
-#import "SSKeychainQuery.h"
-
 @interface PreferencesWindowController ()
 
 @property (nonatomic, strong) GenericAccount *account;


### PR DESCRIPTION
- Correctly uses __weak self in blocks. There were some using self directly
- Fix DTITCReportManager dealloc to correctly remove itself from NSNotificationCenter
- Remove unsed imports
