### PR TITLE
Create UserDefaults constants to avoid the widespread use of strings

### DIFF
--- a/AutoIngest.xcodeproj/project.pbxproj
+++ b/AutoIngest.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 		A7D8C7AD172316D900025675 /* libz.1.2.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.5.dylib; path = usr/lib/libz.1.2.5.dylib; sourceTree = SDKROOT; };
 		A7D8C7DD1723FD5C00025675 /* LastSyncDateValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LastSyncDateValueTransformer.h; sourceTree = "<group>"; };
 		A7D8C7DE1723FD5C00025675 /* LastSyncDateValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LastSyncDateValueTransformer.m; sourceTree = "<group>"; };
+		BA6D12B07D998A4E3684E2AC /* AIUserDefaultsKeysConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIUserDefaultsKeysConstants.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -620,6 +621,7 @@
 				A7D8C7DE1723FD5C00025675 /* LastSyncDateValueTransformer.m */,
 				1DA477B91723FDFA0048EACA /* StatusItemView.h */,
 				1DA477BA1723FDFB0048EACA /* StatusItemView.m */,
+				BA6D12B07D998A4E3684E2AC /* AIUserDefaultsKeysConstants.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";

--- a/AutoIngest/AutoIngest-Prefix.pch
+++ b/AutoIngest/AutoIngest-Prefix.pch
@@ -5,4 +5,5 @@
 #ifdef __OBJC__
 	#import <Cocoa/Cocoa.h>
     #import "DTITC.h"
+    #import "AIUserDefaultsKeysConstants.h"
 #endif

--- a/AutoIngest/Source/AIUserDefaultsKeysConstants.h
+++ b/AutoIngest/Source/AIUserDefaultsKeysConstants.h
@@ -1,0 +1,11 @@
+//
+//  Created by felipecypriano on 27/04/13.
+//  Copyright (c) 2013 Cocoanetics. All rights reserved.
+//
+
+
+static NSString *const AIUserDefaultsDownloadFolderPathKey = @"DownloadFolderPath";
+static NSString *const AIUserDefaultsLastSuccessfulSyncDateKey = @"DownloadLastSuccessfulSync";
+static NSString *const AIUserDefaultsShouldAutoSyncKey = @"DownloadAutoSync";
+static NSString *const AIUserDefaultsShouldUncompressReportsKey = @"UncompressReports";
+static NSString *const AIUserDefaultsVendoIDKey = @"DownloadVendorID";

--- a/AutoIngest/Source/AppDelegate.m
+++ b/AutoIngest/Source/AppDelegate.m
@@ -10,7 +10,6 @@
 
 #import "PreferencesWindowController.h"
 #import "DTITCReportManager.h"
-#import "AccountManager.h"
 
 #import "StatusItemView.h"
 
@@ -43,13 +42,13 @@
     }
     
     // replace tilde if necessary
-    NSString *downloadPath = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadFolderPath"];
+    NSString *downloadPath = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsDownloadFolderPathKey];
     
     if ([downloadPath hasPrefix:@"~"])
     {
         downloadPath = [downloadPath stringByExpandingTildeInPath];
         
-        [[NSUserDefaults standardUserDefaults] setObject:downloadPath forKey:@"DownloadFolderPath"];
+        [[NSUserDefaults standardUserDefaults] setObject:downloadPath forKey:AIUserDefaultsDownloadFolderPathKey];
     }
 }
 
@@ -79,7 +78,7 @@
 
 	[nc addObserver:self selector:@selector(menuWillOpen:) name:AIMenuWillOpenNotification object:nil];
 
-	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DownloadAutoSync"])
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:AIUserDefaultsShouldAutoSyncKey])
 	{
 		[reportManager startAutoSyncTimer];
 	}
@@ -179,8 +178,8 @@
 			 [note setTitle:@"AutoIngest"];
 			 NSString *infoText = [NSString stringWithFormat:@"Report download complete"];
 			 [note setInformativeText:infoText];
-			 
-			 [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:@"DownloadLastSuccessfulSync"];
+
+             [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:AIUserDefaultsLastSuccessfulSyncDateKey];
 		 }
        
         NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];

--- a/AutoIngest/Source/DTITCReportManager.m
+++ b/AutoIngest/Source/DTITCReportManager.m
@@ -71,7 +71,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 - (void)_downloadAllReportsOfType:(ITCReportType)reportType subType:(ITCReportSubType)reportSubType dateType:(ITCReportDateType)reportDateType fromAccount:(GenericAccount *)account
 {
 	DTITCReportDownloadOperation *op = [[DTITCReportDownloadOperation alloc] initForReportsOfType:reportType subType:reportSubType dateType:reportDateType fromAccount:account vendorID:_vendorID intoFolder:_reportFolder];
-	op.uncompressFiles = [[NSUserDefaults standardUserDefaults] boolForKey:@"UncompressReports"];
+	op.uncompressFiles = [[NSUserDefaults standardUserDefaults] boolForKey:AIUserDefaultsShouldUncompressReportsKey];
 	op.delegate = self;
 	
 	[_queue addOperation:op];
@@ -223,7 +223,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 		return NO;
 	}
 	
-	NSString *vendorID = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadVendorID"];
+	NSString *vendorID = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsVendoIDKey];
 	
 	// vendor ID must be only digits
 	if ([[vendorID stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"0123456789"]] length])
@@ -236,7 +236,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 		return NO;
 	}
 	
-	NSString *reportFolder = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadFolderPath"];
+	NSString *reportFolder = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsDownloadFolderPathKey];
 	BOOL isDirectory = NO;
 	if ([[NSFileManager defaultManager] fileExistsAtPath:reportFolder isDirectory:&isDirectory])
 	{
@@ -311,8 +311,8 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 	
 	BOOL needsToStopSync = NO;
 	
-	NSString *reportFolder = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadFolderPath"];
-	NSString *vendorID = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadVendorID"];
+	NSString *reportFolder = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsDownloadFolderPathKey];
+	NSString *vendorID = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsVendoIDKey];
    
 	if (![_reportFolder isEqualToString:reportFolder])
 	{
@@ -336,7 +336,7 @@ NSString * const DTITCReportManagerSyncDidFinishNotification = @"DTITCReportMana
 		[self stopSync];
 	}
 	
-	BOOL needsAutoSync = [[NSUserDefaults standardUserDefaults] boolForKey:@"DownloadAutoSync"];
+	BOOL needsAutoSync = [[NSUserDefaults standardUserDefaults] boolForKey:AIUserDefaultsShouldAutoSyncKey];
 	BOOL hasActiveTimer = (_autoSyncTimer!=nil);
 	
 	if (needsAutoSync != hasActiveTimer)

--- a/AutoIngest/Source/PreferencesWindowController.m
+++ b/AutoIngest/Source/PreferencesWindowController.m
@@ -9,7 +9,6 @@
 #import "PreferencesWindowController.h"
 
 #import "AccountManager.h"
-#import "GenericAccount.h"
 
 @interface PreferencesWindowController ()
 
@@ -68,7 +67,7 @@
     openPanel.prompt = @"Choose";
     
     // set default path
-    NSString *path = [[NSUserDefaults standardUserDefaults] objectForKey:@"DownloadFolderPath"];
+    NSString *path = [[NSUserDefaults standardUserDefaults] objectForKey:AIUserDefaultsDownloadFolderPathKey];
     NSURL *URL = [NSURL fileURLWithPath:path];
     if (URL)
     {
@@ -81,7 +80,7 @@
 		if (result == NSFileHandlingPanelOKButton)
 		{
             NSString *path = [[openPanel URL] path];
-            [[NSUserDefaults standardUserDefaults] setObject:path forKey:@"DownloadFolderPath"];
+            [[NSUserDefaults standardUserDefaults] setObject:path forKey:AIUserDefaultsDownloadFolderPathKey];
 		}
 	}];
 }


### PR DESCRIPTION
- Add UIUserDefaultsKeysConstants.h and import it in the .pch
- Refactor all code uses of NSStrings as keys of NSUserDefaults. This makes code reuse and future refactor safer
