### PR TITLE
Fix crash when the download folder contains spaces

### DIFF
--- a/AutoIngest/Source/ReportOrganizer.m
+++ b/AutoIngest/Source/ReportOrganizer.m
@@ -78,7 +78,7 @@
 {
     NSFileManager *fileManager = [[NSFileManager alloc] init];
     NSError *error = nil;
-    NSArray *contents = [fileManager contentsOfDirectoryAtURL:[[NSURL alloc] initWithString:folder]
+    NSArray *contents = [fileManager contentsOfDirectoryAtURL:[NSURL fileURLWithPath:folder isDirectory:YES]
                                    includingPropertiesForKeys:@[NSURLIsDirectoryKey, NSURLNameKey]
                                                       options:NSDirectoryEnumerationSkipsHiddenFiles
                                                         error:&error];


### PR DESCRIPTION
Uses the correct constructor to make a `NSURL` from a path.

Closes issue #27 
